### PR TITLE
feat(Checkout): removes n+1 during checkout

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -32,7 +32,7 @@ module Spree
 
       def stock_locations_with_requested_variants
         Spree::StockLocation.active.joins(:stock_items).
-          where(spree_stock_items: { variant_id: requested_variant_ids })
+          where(spree_stock_items: { variant_id: requested_variant_ids }).distinct
       end
 
       def requested_variant_ids

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -46,11 +46,11 @@ module Spree
       #   {<variant_id> => <stock_item>, ...}
       def stock_item_lookup
         @stock_item_lookup ||=
-          Spree::StockItem.
-          where(variant_id: inventory_units.map(&:variant_id).uniq).
-          where(stock_location_id: stock_location.id).
-          map { |stock_item| [stock_item.variant_id, stock_item] }.to_h
-          # there is only one stock item per variant in a stock location
+        Spree::StockItem.
+        where(variant_id: inventory_units.map(&:variant_id).uniq).
+        where(stock_location_id: stock_location.id).
+        map { |stock_item| [stock_item.variant_id, stock_item] }.to_h
+        # there is only one stock item per variant in a stock location
       end
 
       def build_splitter

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -26,8 +26,8 @@ module Spree
             next unless stock_item
 
             on_hand, backordered = stock_item.fill_status(units.size)
-            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand.positive?
-            package.add_multiple units.slice!(0, backordered), :backordered if backordered.positive?
+            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
+            package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
           else
             package.add_multiple units
           end

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -26,8 +26,8 @@ module Spree
             next unless stock_item
 
             on_hand, backordered = stock_item.fill_status(units.size)
-            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
-            package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
+            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand.positive?
+            package.add_multiple units.slice!(0, backordered), :backordered if backordered.positive?
           else
             package.add_multiple units
           end
@@ -45,11 +45,12 @@ module Spree
       # Returns a lookup table in the form of:
       #   {<variant_id> => <stock_item>, ...}
       def stock_item_lookup
-        @stock_item_lookup ||= Spree::StockItem.
+        @stock_item_lookup ||=
+          Spree::StockItem.
           where(variant_id: inventory_units.map(&:variant_id).uniq).
           where(stock_location_id: stock_location.id).
-          map { |stock_item| [stock_item.variant_id, stock_item] }.
-          to_h # there is only one stock item per variant in a stock location
+          map { |stock_item| [stock_item.variant_id, stock_item] }.to_h
+          # there is only one stock item per variant in a stock location
       end
 
       def build_splitter

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -3,7 +3,7 @@ module Spree
     class Packer
       attr_reader :stock_location, :inventory_units, :splitters
 
-      def initialize(stock_location, inventory_units, splitters=[Splitter::Base])
+      def initialize(stock_location, inventory_units, splitters = [Splitter::Base])
         @stock_location = stock_location
         @inventory_units = inventory_units
         @splitters = splitters
@@ -31,7 +31,6 @@ module Spree
           else
             package.add_multiple units
           end
-
         end
         package
       end
@@ -46,10 +45,10 @@ module Spree
       #   {<variant_id> => <stock_item>, ...}
       def stock_item_lookup
         @stock_item_lookup ||=
-        Spree::StockItem.
-        where(variant_id: inventory_units.map(&:variant_id).uniq).
-        where(stock_location_id: stock_location.id).
-        map { |stock_item| [stock_item.variant_id, stock_item] }.to_h
+          Spree::StockItem.
+          where(variant_id: inventory_units.map(&:variant_id).uniq).
+          where(stock_location_id: stock_location.id).
+          map { |stock_item| [stock_item.variant_id, stock_item] }.to_h
         # there is only one stock item per variant in a stock location
       end
 

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -59,7 +59,7 @@ module Spree
     end
 
     def reduce_count_on_hand_to_zero
-      self.set_count_on_hand(0) if count_on_hand > 0
+      self.set_count_on_hand(0) if count_on_hand.positive?
     end
 
     def fill_status(quantity)
@@ -68,7 +68,7 @@ module Spree
         backordered = 0
       else
         on_hand = count_on_hand
-        on_hand = 0 if on_hand < 0
+        on_hand = 0 if on_hand.negative?
         backordered = backorderable? ? (quantity - on_hand) : 0
       end
 
@@ -77,14 +77,14 @@ module Spree
 
     private
       def verify_count_on_hand?
-        count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)
+        count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand.negative?)
       end
 
       # Process backorders based on amount of stock received
       # If stock was -20 and is now -15 (increase of 5 units), then we should process 5 inventory orders.
       # If stock was -20 but then was -25 (decrease of 5 units), do nothing.
       def process_backorders(number)
-        if number > 0
+        if number.positive?
           backordered_inventory_units.first(number).each do |unit|
             unit.fill_backorder
           end

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -77,7 +77,7 @@ module Spree
 
     private
       def verify_count_on_hand?
-        count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand.negative?)
+        count_on_hand_changed? && !backorderable? && count_on_hand < count_on_hand_was && count_on_hand.negative?
       end
 
       # Process backorders based on amount of stock received

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -62,6 +62,19 @@ module Spree
       self.set_count_on_hand(0) if count_on_hand > 0
     end
 
+    def fill_status(quantity)
+      if count_on_hand >= quantity
+        on_hand = quantity
+        backordered = 0
+      else
+        on_hand = count_on_hand
+        on_hand = 0 if on_hand < 0
+        backordered = backorderable? ? (quantity - on_hand) : 0
+      end
+
+      [on_hand, backordered]
+    end
+
     private
       def verify_count_on_hand?
         count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -59,7 +59,7 @@ module Spree
     end
 
     def reduce_count_on_hand_to_zero
-      self.set_count_on_hand(0) if count_on_hand.positive?
+      set_count_on_hand(0) if count_on_hand.positive?
     end
 
     def fill_status(quantity)

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -59,7 +59,7 @@ module Spree
     end
 
     def reduce_count_on_hand_to_zero
-      set_count_on_hand(0) if count_on_hand.positive?
+      set_count_on_hand(0) if count_on_hand > 0
     end
 
     def fill_status(quantity)
@@ -68,7 +68,7 @@ module Spree
         backordered = 0
       else
         on_hand = count_on_hand
-        on_hand = 0 if on_hand.negative?
+        on_hand = 0 if on_hand < 0
         backordered = backorderable? ? (quantity - on_hand) : 0
       end
 
@@ -77,14 +77,14 @@ module Spree
 
     private
       def verify_count_on_hand?
-        count_on_hand_changed? && !backorderable? && count_on_hand < count_on_hand_was && count_on_hand.negative?
+        count_on_hand_changed? && !backorderable? && count_on_hand < count_on_hand_was && count_on_hand < 0
       end
 
       # Process backorders based on amount of stock received
       # If stock was -20 and is now -15 (increase of 5 units), then we should process 5 inventory orders.
       # If stock was -20 but then was -25 (decrease of 5 units), do nothing.
       def process_backorders(number)
-        if number.positive?
+        if number > 0
           backordered_inventory_units.first(number).each do |unit|
             unit.fill_backorder
           end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -83,17 +83,7 @@ module Spree
 
     def fill_status(variant, quantity)
       if item = stock_item(variant)
-
-        if item.count_on_hand >= quantity
-          on_hand = quantity
-          backordered = 0
-        else
-          on_hand = item.count_on_hand
-          on_hand = 0 if on_hand < 0
-          backordered = item.backorderable? ? (quantity - on_hand) : 0
-        end
-
-        [on_hand, backordered]
+        item.fill_status(quantity)
       else
         [0, 0]
       end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Packer, :type => :model do
-      let!(:inventory_units) { 5.times.map { build(:inventory_unit) } }
+      let!(:inventory_units) { Array.new(5) { build(:inventory_unit) } }
       let(:stock_location) { create(:stock_location) }
 
       subject { Packer.new(stock_location, inventory_units) }

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Packer, :type => :model do
-      let(:inventory_units) { [InventoryUnit.new(variant: create(:variant))] }
+      let!(:inventory_units) { 5.times.map { build(:inventory_unit) } }
       let(:stock_location) { create(:stock_location) }
 
       subject { Packer.new(stock_location, inventory_units) }
@@ -23,21 +23,19 @@ module Spree
       end
 
       context 'default_package' do
-        let!(:inventory_units) { 2.times.map { InventoryUnit.new variant: create(:variant) } }
 
         it 'contains all the items' do
           package = subject.default_package
-          expect(package.contents.size).to eq 2
+          expect(package.contents.size).to eq 5
         end
 
         it 'variants are added as backordered without enough on_hand' do
-          expect(stock_location).to receive(:fill_status).exactly(2).times.and_return(
-            *(Array.new(1, [1,0]) + Array.new(1, [0,1]))
-          )
+          inventory_units[0..2].each { |iu| stock_location.stock_item(iu.variant_id).set_count_on_hand(1) }
+          inventory_units[3..4].each { |iu| stock_location.stock_item(iu.variant_id).set_count_on_hand(0) }
 
           package = subject.default_package
-          expect(package.on_hand.size).to eq 1
-          expect(package.backordered.size).to eq 1
+          expect(package.on_hand.size).to eq 3
+          expect(package.backordered.size).to eq 2
         end
 
         context "location doesn't have order items in stock" do

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -165,10 +165,7 @@ module Spree
       end
 
       it 'zero on_hand with all backordered' do
-        zero_stock_item = mock_model(StockItem,
-                                     count_on_hand: 0,
-                                     backorderable?: true)
-        expect(subject).to receive(:stock_item).with(variant).and_return(zero_stock_item)
+        stock_item.set_count_on_hand(0)
 
         on_hand, backordered = subject.fill_status(variant, 20)
         expect(on_hand).to eq 0
@@ -177,8 +174,7 @@ module Spree
 
       context 'when backordering is not allowed' do
         before do
-          @stock_item = mock_model(StockItem, backorderable?: false)
-          expect(subject).to receive(:stock_item).with(variant).and_return(@stock_item)
+          stock_item.update!(backorderable: false)
         end
 
         it 'all on_hand' do
@@ -190,7 +186,7 @@ module Spree
         end
 
         it 'some on_hand' do
-          allow(@stock_item).to receive_messages(count_on_hand: 10)
+          stock_item.set_count_on_hand(10)
 
           on_hand, backordered = subject.fill_status(variant, 20)
           expect(on_hand).to eq 10
@@ -198,7 +194,7 @@ module Spree
         end
 
         it 'zero on_hand' do
-          allow(@stock_item).to receive_messages(count_on_hand: 0)
+          stock_item.set_count_on_hand(0)
 
           on_hand, backordered = subject.fill_status(variant, 20)
           expect(on_hand).to eq 0


### PR DESCRIPTION
Makes the checkout process faster by bypassing a n+1 in packer. stock_location was loading the stock_item for every variant separately which caused a unnecessary delay. Loading it first and then use a hash for looking the stock_items up is a lot faster.
Commit is basically the same as:
solidusio/solidus@5bac41b
thanks to @jordan-brough 🎉 👍

adds also distinct to the query in stock_locations_with_requested_variants. Without this distinct the query would return the stock_location for each variant_id even if they had the same location.