### PR TITLE
fix(Admin::Products): fixes not discontinued on product index

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -105,7 +105,7 @@ module Spree
         return @collection if @collection.present?
         params[:q] ||= {}
         params[:q][:deleted_at_null] ||= "1"
-        params[:q][:discontinue_on_null] ||= "1"
+        params[:q][:not_discontinued] ||= "1"
 
         params[:q][:s] ||= "name asc"
         @collection = super

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -34,7 +34,7 @@
 
           <div class="field checkbox">
             <label>
-              <%= f.check_box :discontinue_on_null, {:checked => params[:q][:discontinue_on_null] == '0'}, '0', '1' %>
+              <%= f.check_box :not_discontinued, {checked: params[:q][:not_discontinued] == '0'}, '0', '1' %>
               <%= Spree.t(:show_discontinued ) %>
             </label>
           </div>

--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -3,6 +3,7 @@ module Spree::RansackableAttributes
   included do
     class_attribute :whitelisted_ransackable_associations
     class_attribute :whitelisted_ransackable_attributes
+    class_attribute :whitelisted_ransackable_scopes
 
     class_attribute :default_ransackable_attributes
     self.default_ransackable_attributes = %w[id name]
@@ -13,6 +14,10 @@ module Spree::RansackableAttributes
 
     def self.ransackable_attributes(*args)
       self.default_ransackable_attributes | (self.whitelisted_ransackable_attributes || [])
+    end
+
+    def self.ransackable_scopes(*args)
+      self.whitelisted_ransackable_scopes || []
     end
   end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -114,6 +114,7 @@ module Spree
 
     self.whitelisted_ransackable_associations = %w[stores variants_including_master master variants]
     self.whitelisted_ransackable_attributes = %w[description name slug discontinue_on]
+    self.whitelisted_ransackable_scopes = %w[not_discontinued]
 
     # the master variant is not a member of the variants array
     def has_variants?

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -186,10 +186,14 @@ module Spree
       where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.zone.now)
     end
 
-    add_search_scope :not_discontinued do
-      where("#{Product.quoted_table_name}.discontinue_on IS NULL or #{Product.quoted_table_name}.discontinue_on >= ?", Time.zone.now)
+    def self.not_discontinued(only_not_discontinued = true)
+      if only_not_discontinued != '0' &&  only_not_discontinued
+        where("#{Product.quoted_table_name}.discontinue_on IS NULL or #{Product.quoted_table_name}.discontinue_on >= ?", Time.zone.now)
+      else
+        all
+      end
     end
-
+    search_scopes << :not_discontinued
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
       available_on ||= Time.current


### PR DESCRIPTION
This pull request fixes a bug in the admin panel on the products index page. If products have a discontinued date they will not be displayed even though their discontinued date is in the future.
